### PR TITLE
fix 🐛(cmd): add spacing between scope and commit type

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,7 +93,7 @@ func constructCommitMessage(cfg *config.Config, typeFlag, scopeFlag, messageFlag
 	}
 
 	if scopeFlag != "" {
-		return fmt.Sprintf("%s(%s): %s", typeMatch, scopeFlag, messageFlag)
+		return fmt.Sprintf("%s (%s): %s", typeMatch, scopeFlag, messageFlag)
 	}
 	return fmt.Sprintf("%s: %s", typeMatch, messageFlag)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,7 +96,7 @@ func constructCommitMessage(cfg *config.Config, typeFlag, scopeFlag, messageFlag
 
 	commitHeader := typeMatch
 	if scopeFlag != "" {
-		commitHeader += fmt.Sprintf(" (%s)", scopeFlag)
+		commitHeader += " " + fmt.Sprintf("(%s)", scopeFlag)
 	}
 
 	return fmt.Sprintf("%s: %s", commitHeader, messageFlag)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,16 +86,21 @@ func constructCommitMessage(cfg *config.Config, typeFlag, scopeFlag, messageFlag
 	for _, t := range cfg.Types {
 		if typeFlag == t.Name {
 			if !cfg.NoEmoji {
-				typeMatch = fmt.Sprintf("%s %s", t.Name, t.Emoji)
+				typeMatch = fmt.Sprintf("%s %s", t.Emoji, t.Name)
+				break
+			} else {
+				typeMatch = t.Name
+				break
 			}
-			break
 		}
 	}
 
+	commitHeader := typeMatch
 	if scopeFlag != "" {
-		return fmt.Sprintf("%s (%s): %s", typeMatch, scopeFlag, messageFlag)
+		commitHeader += fmt.Sprintf(" (%s)", scopeFlag)
 	}
-	return fmt.Sprintf("%s: %s", typeMatch, messageFlag)
+
+	return fmt.Sprintf("%s: %s", commitHeader, messageFlag)
 }
 
 // commit executes a git commit with the given message and body.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,3 @@
-// File: ./cmd/root.go
 package cmd
 
 import (
@@ -19,80 +18,33 @@ var (
 	versionFlag, noVerifyFlag, amendFlag, addFlag bool
 )
 
-// rootCmd is the base command for the goji CLI.
 var rootCmd = &cobra.Command{
-	Use:   "goji",
-	Short: "Goji CLI",
-	Long:  `Goji is a CLI tool to generate conventional commits with emojis`,
-	// SilenceUsage:  true, // Keep as is if desired
-	// SilenceErrors: true, // Keep as is if desired
+	Use:           "goji",
+	Short:         "Goji CLI",
+	Long:          `Goji is a CLI tool to generate conventional commits with emojis`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Access flag values directly via the command object
-		versionFlag, err := cmd.Flags().GetBool("version")
-		if err != nil {
-			return fmt.Errorf("failed to get version flag: %w", err)
-		}
 		if versionFlag {
-			// Use color.Green func for simpler coloring
 			color.Green("goji version: v%s", version)
 			return nil
 		}
 
 		cfg, err := config.ViperConfig()
 		if err != nil {
-			// Error loading config is critical for most operations
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 
-		// Access flags, check for errors
-		typeFlag, err := cmd.Flags().GetString("type")
-		if err != nil {
-			return fmt.Errorf("failed to get type flag: %w", err)
-		}
-		messageFlag, err := cmd.Flags().GetString("message")
-		if err != nil {
-			return fmt.Errorf("failed to get message flag: %w", err)
-		}
-		scopeFlag, err := cmd.Flags().GetString("scope")
-		if err != nil {
-			return fmt.Errorf("failed to get scope flag: %w", err)
-		}
-		noVerifyFlag, err := cmd.Flags().GetBool("no-verify")
-		if err != nil {
-			return fmt.Errorf("failed to get no-verify flag: %w", err)
-		}
-		addFlag, err := cmd.Flags().GetBool("add")
-		if err != nil {
-			return fmt.Errorf("failed to get add flag: %w", err)
-		}
-		amendFlag, err := cmd.Flags().GetBool("amend")
-		if err != nil {
-			return fmt.Errorf("failed to get amend flag: %w", err)
-		}
-		gitFlags, err := cmd.Flags().GetStringArray("git-flag")
-		if err != nil {
-			return fmt.Errorf("failed to get git-flag: %w", err)
-		}
+		typeFlag, _ := cmd.Flags().GetString("type")
+		messageFlag, _ := cmd.Flags().GetString("message")
 
 		var commitMessage, commitBody string
 		if typeFlag != "" && messageFlag != "" {
-			// Use flags for non-interactive mode
-			commitMessage = constructCommitMessage(cfg, typeFlag, scopeFlag, messageFlag) // Pass scopeFlag
-			commitBody = ""                                                               // No body in simple non-interactive mode via flags
+			commitMessage = constructCommitMessage(cfg, typeFlag, "", messageFlag)
 		} else {
-			// Interactive mode
-			// AskQuestions returns []string, expecting [message, body]
-			// TODO: Improve AskQuestions to return a struct for better type safety
-			messages, err := utils.AskQuestions(cfg, typeFlag, messageFlag) // Pass typeFlag, messageFlag for presets
+			messages, err := utils.AskQuestions(cfg, typeFlag, messageFlag)
 			if err != nil {
-				// An error from AskQuestions (like user cancelling the commit) should be handled gracefully.
-				// Check if it's a specific user cancellation error or a real issue.
-				// For now, just return the error.
-				return fmt.Errorf("failed to get commit details from interactive prompt: %w", err)
-			}
-			if len(messages) != 2 {
-				// Defensive check: Ensure AskQuestions returned the expected number of elements
-				return fmt.Errorf("unexpected number of return values from AskQuestions: %d", len(messages))
+				return fmt.Errorf("failed to get commit details: %w", err)
 			}
 			commitMessage, commitBody = messages[0], messages[1]
 		}
@@ -101,14 +53,23 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("commit message cannot be empty")
 		}
 
-		// Pass relevant flags to the git execution function
-		return executeGitCommit(commitMessage, commitBody, cfg.SignOff, noVerifyFlag, addFlag, amendFlag, gitFlags)
+		return executeGitCommit(commitMessage, commitBody, cfg.SignOff)
 	},
 }
 
 // init initializes the flags for the root command.
+//
+// This function sets up the flags for the root command, which are used to specify the type, scope, message,
+// and options for the command. The flags are defined using the `rootCmd.Flags()` method.
+//
+// - `typeFlag` is a string flag that specifies the type from the config file.
+// - `scopeFlag` is a string flag that specifies a custom scope.
+// - `messageFlag` is a string flag that specifies a commit message.
+// - `noVerifyFlag` is a boolean flag that bypasses pre-commit and commit-msg hooks.
+// - `versionFlag` is a boolean flag that displays version information.
+//
+// There are no parameters or return values for this function.
 func init() {
-	// Define flags using package-level variables
 	rootCmd.Flags().StringVarP(&typeFlag, "type", "t", "", "Specify the type from the config file")
 	rootCmd.Flags().StringVarP(&scopeFlag, "scope", "s", "", "Specify a custom scope")
 	rootCmd.Flags().StringVarP(&messageFlag, "message", "m", "", "Specify a commit message")
@@ -117,16 +78,9 @@ func init() {
 	rootCmd.Flags().BoolVarP(&addFlag, "add", "a", false, "Automatically stage files that have been modified and deleted")
 	rootCmd.Flags().BoolVar(&amendFlag, "amend", false, "Change last commit")
 
-	// gitFlags is already a slice, so StringArrayVar is correct
-	rootCmd.Flags().StringArrayVar(&gitFlags, "git-flag", []string{}, "Additional Git flags (can be used multiple times)")
-
-	// Add the 'check' and 'init' commands (assuming they are defined elsewhere and added to rootCmd)
-	// rootCmd.AddCommand(checkCmd)
-	// rootCmd.AddCommand(initCmd)
+	rootCmd.Flags().StringArrayVar(&gitFlags, "git-flag", []string{}, "Git flags (can be used multiple times)")
 }
 
-// constructCommitMessage formats the commit message string based on config and flags.
-// It handles adding emoji and scope according to the configuration.
 func constructCommitMessage(cfg *config.Config, typeFlag, scopeFlag, messageFlag string) string {
 	typeMatch := typeFlag // Default to the raw typeFlag
 	for _, t := range cfg.Types {
@@ -135,76 +89,69 @@ func constructCommitMessage(cfg *config.Config, typeFlag, scopeFlag, messageFlag
 				typeMatch = fmt.Sprintf("%s %s", t.Emoji, t.Name)
 				break
 			} else {
-				typeMatch = t.Name // Use just the name if NoEmoji is true
+				typeMatch = t.Name
 				break
 			}
 		}
 	}
 
-	// Add scope if present
 	commitHeader := typeMatch
 	if scopeFlag != "" {
 		commitHeader += fmt.Sprintf("(%s)", scopeFlag)
 	}
 
-	// Combine header and subject
 	return fmt.Sprintf("%s: %s", commitHeader, messageFlag)
 }
 
-// executeGitCommit executes a git commit with the given message and body and flags.
+// commit executes a git commit with the given message and body.
 //
 // Parameters:
-// - message: the commit header (type[(scope)]: subject).
-// - body: the commit body (optional).
-// - sign: a boolean indicating whether to add a Signed-off-by trailer (from config).
-// - noVerify: a boolean indicating whether to bypass hooks (from flag).
-// - add: a boolean indicating whether to auto-stage files (from flag).
-// - amend: a boolean indicating whether to amend the last commit (from flag).
-// - gitFlags: additional raw git flags (from flag array).
+// - message: the commit message.
+// - body: the commit body.
+// - sign: a boolean indicating whether to add a Signed-off-by trailer.
+// - amend: a boolean indicating whether to amend the last commit.
+// - commits the changes to git
 //
 // Returns:
 // - error: an error if the git commit execution fails.
-func executeGitCommit(message, body string, signOff, noVerify, add, amend bool, extraGitFlags []string) error {
-	args := []string{"commit"}
-
-	if noVerify {
-		args = append(args, "--no-verify")
-	}
-	if add {
-		args = append(args, "-a")
-	}
-	if amend {
-		args = append(args, "--amend")
-	}
-
-	args = append(args, "-m", message)
+func executeGitCommit(message, body string, signOff bool) error {
+	args := []string{"commit", "-m", message}
 	if body != "" {
 		args = append(args, "-m", body)
 	}
-
 	if signOff {
 		args = append(args, "--signoff")
 	}
-
-	args = append(args, extraGitFlags...)
-
-	fmt.Println("Executing command:", "git", strings.Join(args, " "))
+	var extraArgs []string
+	if noVerifyFlag {
+		extraArgs = append(extraArgs, "--no-verify")
+	}
+	if addFlag {
+		extraArgs = append(extraArgs, "-a")
+	}
+	if amendFlag {
+		extraArgs = append(extraArgs, "--amend")
+	}
+	// Add all dynamically passed Git flags
+	baseArgs := append(args, extraArgs...)
+	args = append(baseArgs, gitFlags...)
 
 	gitCmd := exec.Command("git", args...)
 	output, err := gitCmd.CombinedOutput()
-
-	// fmt.Printf("Git command output:\n%s\n", output)
-
+	// Print the executed command
+	fmt.Println("Executing command:", strings.Join(append([]string{"git"}, args...), " "))
+	// Print the command output
 	if err != nil {
-		return fmt.Errorf("git command failed with error: %v\nCommand: git %s\nOutput: %s", err, strings.Join(args, " "), output)
+		return fmt.Errorf("git command failed: %v\nOutput: %s", err, output)
 	}
+	fmt.Printf("Git command output:\n%s", output)
 
 	return nil
 }
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,11 @@
+// File: ./cmd/root.go
 package cmd
 
 import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/muandane/goji/pkg/config"
@@ -17,33 +19,80 @@ var (
 	versionFlag, noVerifyFlag, amendFlag, addFlag bool
 )
 
+// rootCmd is the base command for the goji CLI.
 var rootCmd = &cobra.Command{
-	Use:           "goji",
-	Short:         "Goji CLI",
-	Long:          `Goji is a CLI tool to generate conventional commits with emojis`,
-	SilenceUsage:  true,
-	SilenceErrors: true,
+	Use:   "goji",
+	Short: "Goji CLI",
+	Long:  `Goji is a CLI tool to generate conventional commits with emojis`,
+	// SilenceUsage:  true, // Keep as is if desired
+	// SilenceErrors: true, // Keep as is if desired
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Access flag values directly via the command object
+		versionFlag, err := cmd.Flags().GetBool("version")
+		if err != nil {
+			return fmt.Errorf("failed to get version flag: %w", err)
+		}
 		if versionFlag {
+			// Use color.Green func for simpler coloring
 			color.Green("goji version: v%s", version)
 			return nil
 		}
 
 		cfg, err := config.ViperConfig()
 		if err != nil {
+			// Error loading config is critical for most operations
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 
-		typeFlag, _ := cmd.Flags().GetString("type")
-		messageFlag, _ := cmd.Flags().GetString("message")
+		// Access flags, check for errors
+		typeFlag, err := cmd.Flags().GetString("type")
+		if err != nil {
+			return fmt.Errorf("failed to get type flag: %w", err)
+		}
+		messageFlag, err := cmd.Flags().GetString("message")
+		if err != nil {
+			return fmt.Errorf("failed to get message flag: %w", err)
+		}
+		scopeFlag, err := cmd.Flags().GetString("scope")
+		if err != nil {
+			return fmt.Errorf("failed to get scope flag: %w", err)
+		}
+		noVerifyFlag, err := cmd.Flags().GetBool("no-verify")
+		if err != nil {
+			return fmt.Errorf("failed to get no-verify flag: %w", err)
+		}
+		addFlag, err := cmd.Flags().GetBool("add")
+		if err != nil {
+			return fmt.Errorf("failed to get add flag: %w", err)
+		}
+		amendFlag, err := cmd.Flags().GetBool("amend")
+		if err != nil {
+			return fmt.Errorf("failed to get amend flag: %w", err)
+		}
+		gitFlags, err := cmd.Flags().GetStringArray("git-flag")
+		if err != nil {
+			return fmt.Errorf("failed to get git-flag: %w", err)
+		}
 
 		var commitMessage, commitBody string
 		if typeFlag != "" && messageFlag != "" {
-			commitMessage = constructCommitMessage(cfg, typeFlag, "", messageFlag)
+			// Use flags for non-interactive mode
+			commitMessage = constructCommitMessage(cfg, typeFlag, scopeFlag, messageFlag) // Pass scopeFlag
+			commitBody = ""                                                               // No body in simple non-interactive mode via flags
 		} else {
-			messages, err := utils.AskQuestions(cfg, typeFlag, messageFlag)
+			// Interactive mode
+			// AskQuestions returns []string, expecting [message, body]
+			// TODO: Improve AskQuestions to return a struct for better type safety
+			messages, err := utils.AskQuestions(cfg, typeFlag, messageFlag) // Pass typeFlag, messageFlag for presets
 			if err != nil {
-				return fmt.Errorf("failed to get commit details: %w", err)
+				// An error from AskQuestions (like user cancelling the commit) should be handled gracefully.
+				// Check if it's a specific user cancellation error or a real issue.
+				// For now, just return the error.
+				return fmt.Errorf("failed to get commit details from interactive prompt: %w", err)
+			}
+			if len(messages) != 2 {
+				// Defensive check: Ensure AskQuestions returned the expected number of elements
+				return fmt.Errorf("unexpected number of return values from AskQuestions: %d", len(messages))
 			}
 			commitMessage, commitBody = messages[0], messages[1]
 		}
@@ -52,23 +101,14 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("commit message cannot be empty")
 		}
 
-		return executeGitCommit(commitMessage, commitBody, cfg.SignOff)
+		// Pass relevant flags to the git execution function
+		return executeGitCommit(commitMessage, commitBody, cfg.SignOff, noVerifyFlag, addFlag, amendFlag, gitFlags)
 	},
 }
 
 // init initializes the flags for the root command.
-//
-// This function sets up the flags for the root command, which are used to specify the type, scope, message,
-// and options for the command. The flags are defined using the `rootCmd.Flags()` method.
-//
-// - `typeFlag` is a string flag that specifies the type from the config file.
-// - `scopeFlag` is a string flag that specifies a custom scope.
-// - `messageFlag` is a string flag that specifies a commit message.
-// - `noVerifyFlag` is a boolean flag that bypasses pre-commit and commit-msg hooks.
-// - `versionFlag` is a boolean flag that displays version information.
-//
-// There are no parameters or return values for this function.
 func init() {
+	// Define flags using package-level variables
 	rootCmd.Flags().StringVarP(&typeFlag, "type", "t", "", "Specify the type from the config file")
 	rootCmd.Flags().StringVarP(&scopeFlag, "scope", "s", "", "Specify a custom scope")
 	rootCmd.Flags().StringVarP(&messageFlag, "message", "m", "", "Specify a commit message")
@@ -77,80 +117,94 @@ func init() {
 	rootCmd.Flags().BoolVarP(&addFlag, "add", "a", false, "Automatically stage files that have been modified and deleted")
 	rootCmd.Flags().BoolVar(&amendFlag, "amend", false, "Change last commit")
 
-	rootCmd.Flags().StringArrayVar(&gitFlags, "git-flag", []string{}, "Git flags (can be used multiple times)")
+	// gitFlags is already a slice, so StringArrayVar is correct
+	rootCmd.Flags().StringArrayVar(&gitFlags, "git-flag", []string{}, "Additional Git flags (can be used multiple times)")
+
+	// Add the 'check' and 'init' commands (assuming they are defined elsewhere and added to rootCmd)
+	// rootCmd.AddCommand(checkCmd)
+	// rootCmd.AddCommand(initCmd)
 }
 
+// constructCommitMessage formats the commit message string based on config and flags.
+// It handles adding emoji and scope according to the configuration.
 func constructCommitMessage(cfg *config.Config, typeFlag, scopeFlag, messageFlag string) string {
-	typeMatch := typeFlag
+	typeMatch := typeFlag // Default to the raw typeFlag
 	for _, t := range cfg.Types {
 		if typeFlag == t.Name {
 			if !cfg.NoEmoji {
 				typeMatch = fmt.Sprintf("%s %s", t.Emoji, t.Name)
 				break
 			} else {
-				typeMatch = t.Name
+				typeMatch = t.Name // Use just the name if NoEmoji is true
 				break
 			}
 		}
 	}
 
+	// Add scope if present
 	commitHeader := typeMatch
 	if scopeFlag != "" {
-		commitHeader += " " + fmt.Sprintf("(%s)", scopeFlag)
+		commitHeader += fmt.Sprintf("(%s)", scopeFlag)
 	}
 
+	// Combine header and subject
 	return fmt.Sprintf("%s: %s", commitHeader, messageFlag)
 }
 
-// commit executes a git commit with the given message and body.
+// executeGitCommit executes a git commit with the given message and body and flags.
 //
 // Parameters:
-// - message: the commit message.
-// - body: the commit body.
-// - sign: a boolean indicating whether to add a Signed-off-by trailer.
-// - amend: a boolean indicating whether to amend the last commit.
-// - commits the changes to git
+// - message: the commit header (type[(scope)]: subject).
+// - body: the commit body (optional).
+// - sign: a boolean indicating whether to add a Signed-off-by trailer (from config).
+// - noVerify: a boolean indicating whether to bypass hooks (from flag).
+// - add: a boolean indicating whether to auto-stage files (from flag).
+// - amend: a boolean indicating whether to amend the last commit (from flag).
+// - gitFlags: additional raw git flags (from flag array).
 //
 // Returns:
 // - error: an error if the git commit execution fails.
-func executeGitCommit(message, body string, signOff bool) error {
-	args := []string{"commit", "-m", message}
+func executeGitCommit(message, body string, signOff, noVerify, add, amend bool, extraGitFlags []string) error {
+	args := []string{"commit"}
+
+	if noVerify {
+		args = append(args, "--no-verify")
+	}
+	if add {
+		args = append(args, "-a")
+	}
+	if amend {
+		args = append(args, "--amend")
+	}
+
+	args = append(args, "-m", message)
 	if body != "" {
 		args = append(args, "-m", body)
 	}
+
 	if signOff {
 		args = append(args, "--signoff")
 	}
-	var extraArgs []string
-	if noVerifyFlag {
-		extraArgs = append(extraArgs, "--no-verify")
-	}
-	if addFlag {
-		extraArgs = append(extraArgs, "-a")
-	}
-	if amendFlag {
-		extraArgs = append(extraArgs, "--amend")
-	}
-	// Add all dynamically passed Git flags
-	baseArgs := append(args, extraArgs...)
-	args = append(baseArgs, gitFlags...)
+
+	args = append(args, extraGitFlags...)
+
+	fmt.Println("Executing command:", "git", strings.Join(args, " "))
 
 	gitCmd := exec.Command("git", args...)
 	output, err := gitCmd.CombinedOutput()
-	// Print the executed command
-	// fmt.Println("Executing command:", strings.Join(append([]string{"git"}, args...), " "))
-	// Print the command output
+
+	// fmt.Printf("Git command output:\n%s\n", output)
+
 	if err != nil {
-		return fmt.Errorf("git command failed: %v\nOutput: %s", err, output)
+		return fmt.Errorf("git command failed with error: %v\nCommand: git %s\nOutput: %s", err, strings.Join(args, " "), output)
 	}
-	fmt.Printf("Git command output:\n%s", output)
 
 	return nil
 }
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/fatih/color"
 	"github.com/muandane/goji/pkg/config"
@@ -139,7 +138,7 @@ func executeGitCommit(message, body string, signOff bool) error {
 	gitCmd := exec.Command("git", args...)
 	output, err := gitCmd.CombinedOutput()
 	// Print the executed command
-	fmt.Println("Executing command:", strings.Join(append([]string{"git"}, args...), " "))
+	// fmt.Println("Executing command:", strings.Join(append([]string{"git"}, args...), " "))
 	// Print the command output
 	if err != nil {
 		return fmt.Errorf("git command failed: %v\nOutput: %s", err, output)

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 )
 
 // main is the entry point of the Go program.
-//
 // It calls the Execute function from the cmd package to execute the command.
 func main() {
 	cmd.Execute()

--- a/pkg/utils/askQuestions.go
+++ b/pkg/utils/askQuestions.go
@@ -94,9 +94,11 @@ func AskQuestions(config *config.Config, presetType, presetMessage string) ([]st
 
 	commitMessage := commitType
 	if commitScope != "" {
-		commitMessage += fmt.Sprintf("(%s)", commitScope)
+		commitMessage += fmt.Sprintf(" (%s)", strings.TrimSpace(commitScope))
 	}
-	commitMessage += fmt.Sprintf(": %s", commitSubject)
+	commitMessage += fmt.Sprintf(": %s", strings.TrimSpace(commitSubject))
 
-	return []string{commitMessage, commitDescription}, nil
+	commitBody := strings.TrimSpace(commitDescription)
+
+	return []string{commitMessage, commitBody}, nil
 }


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add space between commit scope and commit type #96

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the [CHANGELOG](https://github.com/muandane/goji/blob/main/CHANGELOG.md) listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`